### PR TITLE
refactor: read API keys from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,29 @@ ai-grammar-checker/
 
 ### API密钥配置
 
-需要获取AI服务的API密钥：
+建议使用环境变量或系统密钥管理器保存API密钥：
 
 **OpenAI API密钥：**
 1. 访问 [OpenAI Platform](https://platform.openai.com/api-keys)
 2. 创建新的API密钥
-3. 复制密钥到配置中
+3. 设置环境变量 `OPENAI_API_KEY`
 
 **Gemini API密钥：**
 1. 访问 [Google AI Studio](https://makersuite.google.com/app/apikey)
 2. 获取API密钥
-3. 复制密钥到配置中
+3. 设置环境变量 `GEMINI_API_KEY`
+
+**示例：**
+```bash
+# Linux/macOS
+export OPENAI_API_KEY="你的OpenAI密钥"
+export GEMINI_API_KEY="你的Gemini密钥"
+
+# Windows PowerShell
+setx OPENAI_API_KEY "你的OpenAI密钥"
+setx GEMINI_API_KEY "你的Gemini密钥"
+```
+程序将在运行时自动从环境变量读取密钥。`config.json` 不再保存实际密钥，如需本地保存，请自行加密或使用系统密钥管理器。
 
 ### 配置文件说明
 
@@ -79,8 +91,6 @@ ai-grammar-checker/
 
 ```json
 {
-  "openai_api_key": "你的OpenAI密钥",
-  "gemini_api_key": "你的Gemini密钥",
   "provider": "openai",
   "model": "gpt-3.5-turbo",
   "language": "中文",
@@ -250,7 +260,7 @@ Excel文件包含以下列：
 ### 安全提醒
 1. **API密钥安全**：不要在公共场所或不安全的环境中输入API密钥
 2. **数据隐私**：上传的文档内容会发送给AI服务商
-3. **配置文件**：本地保存的配置文件包含API密钥，注意保护
+3. **配置文件**：默认不再保存API密钥，如需本地保存请自行加密或使用系统密钥管理器
 
 ### 成本控制
 1. **API计费**：每次调用AI API都会产生费用

--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
   "model": "gpt-3.5-turbo",
-  "openai_api_key": "你的OpenAI API密钥",
-  "gemini_api_key": "你的Gemini API密钥",
   "max_retries": 3,
   "retry_delay": 1,
   "session_refresh_interval": 3,

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -363,8 +363,6 @@ class MainWindow(QMainWindow):
     def save_config(self):
         """保存配置"""
         config = {
-            "openai_api_key": self.openai_key_input.text(),
-            "gemini_api_key": self.gemini_key_input.text(),
             "provider": self.provider_combo.currentText(),
             "model": self.model_combo.currentText(),
             "language": "中文" if self.chinese_radio.isChecked() else "English",
@@ -388,8 +386,8 @@ class MainWindow(QMainWindow):
                 with open("config.json", "r", encoding="utf-8") as f:
                     config = json.load(f)
                 
-                self.openai_key_input.setText(config.get("openai_api_key", ""))
-                self.gemini_key_input.setText(config.get("gemini_api_key", ""))
+                self.openai_key_input.setText(os.getenv("OPENAI_API_KEY", config.get("openai_api_key", "")))
+                self.gemini_key_input.setText(os.getenv("GEMINI_API_KEY", config.get("gemini_api_key", "")))
                 
                 provider = config.get("provider", "openai")
                 self.provider_combo.setCurrentText(provider)
@@ -435,15 +433,17 @@ class MainWindow(QMainWindow):
         if not self.current_paragraphs:
             QMessageBox.warning(self, "警告", "请先选择Word文档")
             return
-        
+
         provider = self.provider_combo.currentText()
-        api_key = (self.openai_key_input.text() if provider == "openai" 
-                  else self.gemini_key_input.text())
-        
+        api_key = (os.getenv("OPENAI_API_KEY") if provider == "openai"
+                  else os.getenv("GEMINI_API_KEY"))
+        if not api_key:
+            api_key = (self.openai_key_input.text() if provider == "openai"
+                      else self.gemini_key_input.text())
         if not api_key:
             QMessageBox.warning(self, "警告", f"请输入{provider.upper()} API密钥")
             return
-        
+
         # 准备配置
         config = {
             "provider": provider,

--- a/grammar_checker.py
+++ b/grammar_checker.py
@@ -46,8 +46,6 @@ class GrammarChecker:
             # 创建默认配置文件
             default_config = {
                 "model": "gpt-3.5-turbo",  # 或 "gemini-pro"
-                "openai_api_key": "",
-                "gemini_api_key": "",
                 "max_retries": 3,
                 "retry_delay": 1,
                 "session_refresh_interval": 3,
@@ -148,13 +146,11 @@ class GrammarChecker:
         
         # 处理段落
         provider = "gemini" if "gemini" in self.config["model"].lower() else "openai"
-        api_key = (
-            self.config.get("gemini_api_key")
-            if provider == "gemini"
-            else self.config.get("openai_api_key")
-        )
+        api_key = os.getenv("GEMINI_API_KEY") if provider == "gemini" else os.getenv("OPENAI_API_KEY")
         if not api_key:
-            print(f"错误：缺少{provider.upper()} API密钥")
+            api_key = (self.config.get("gemini_api_key") if provider == "gemini" else self.config.get("openai_api_key"))
+        if not api_key:
+            print(f"错误：缺少{provider.upper()} API密钥，请设置环境变量。")
             return
         cfg = {
             "language": "中文",


### PR DESCRIPTION
## Summary
- stop storing API keys in `config.json`
- load API keys from environment variables across CLI, Streamlit, and desktop apps
- document using environment variables or key managers for secret handling

## Testing
- `python3 -m py_compile grammar_checker.py app.py desktop_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a515479c348330b8d727fd8d375f9f