### PR TITLE
Switch Gemini calls to Google AI Studio format

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ The program generates a `config.json` file with the following settings:
 
 **Cost priority:**
 - OpenAI: `gpt-3.5-turbo`
-- Gemini: `gemini-pro`
+- Gemini: `gemini/gemini-pro`
 
 **Quality priority:**
 - OpenAI: `gpt-4o` or `gpt-4-turbo`
-- Gemini: `gemini-1.5-pro`
+- Gemini: `gemini/gemini-1.5-pro`
 
 ### 2. Extra Check Examples
 

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -166,11 +166,11 @@ Excel文件包含以下列：
 
 **成本优先：**
 - OpenAI: `gpt-3.5-turbo`
-- Gemini: `gemini-pro`
+- Gemini: `gemini/gemini-pro`
 
 **质量优先：**
 - OpenAI: `gpt-4o` 或 `gpt-4-turbo`
-- Gemini: `gemini-1.5-pro`
+- Gemini: `gemini/gemini-1.5-pro`
 
 ### 2. 额外检查要求示例
 

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -363,7 +363,13 @@ class MainWindow(QMainWindow):
         if provider == "openai":
             models = ["gpt-5-nano", "gpt-5-mini", "gpt-5", "gpt-4o", "gpt-4o-mini"]
         elif provider == "gemini":
-            models = ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash", "gemini-2.0-flash-lite"]
+            models = [
+                "gemini/gemini-2.5-pro",
+                "gemini/gemini-2.5-flash",
+                "gemini/gemini-2.5-flash-lite",
+                "gemini/gemini-2.0-flash",
+                "gemini/gemini-2.0-flash-lite",
+            ]
         
         self.model_combo.addItems(models)
     

--- a/grammar_checker.py
+++ b/grammar_checker.py
@@ -45,7 +45,7 @@ class GrammarChecker:
         if not os.path.exists(config_path):
             # 创建默认配置文件
             default_config = {
-                "model": "gpt-3.5-turbo",  # 或 "gemini-pro"
+                "model": "gpt-3.5-turbo",  # 或 "gemini/gemini-pro"
                 "max_retries": 3,
                 "retry_delay": 1,
                 "session_refresh_interval": 3,

--- a/utils/checker_core.py
+++ b/utils/checker_core.py
@@ -53,17 +53,18 @@ def call_ai_api(prompt: str, provider: str, model: str, api_key: str, *, max_ret
     if not api_key:
         raise ValueError("API密钥不能为空")
 
+    # Ensure Gemini models use the "gemini/" prefix required by LiteLLM
+    if provider == "gemini" and not model.startswith("gemini/"):
+        model = f"gemini/{model}"
+
     for attempt in range(max_retries):
         try:
-            if provider == "openai":
-                litellm.openai_key = api_key
-            elif provider == "gemini":
-                litellm.gemini_key = api_key
             response = litellm.completion(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=500,
                 temperature=0.3,
+                api_key=api_key,
             )
             return response.choices[0].message.content.strip()
         except Exception as e:


### PR DESCRIPTION
## Summary
- pass API key directly to LiteLLM and auto-prefix Gemini models with `gemini/`
- document new Gemini model naming in README files
- update desktop app model options for Google AI Studio

## Testing
- `python -m py_compile grammar_checker.py utils/checker_core.py desktop_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5522b648883308b8c44100736b010